### PR TITLE
Fixed descriptor issues

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3 :: Only",
 ]
 
@@ -39,7 +40,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-old_glibc = ["rdkit-pypi==2023.3.1b1"]
+old_glibc = ["rdkit-pypi==2022.09.5"]
 
 [project.urls]
 "Homepage" = "https://github.com/scbirlab/schemist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,11 @@ classifiers = [
 
 dependencies = [ 
   "carabiner-tools[pd]>=0.0.3.post1",
-  "datamol",
   "descriptastorus==2.6.1",
   "nemony",
   "openpyxl==3.1.0", 
   "pandas",
-  "rdkit-pypi",
+  "rdkit>=2022.09.5",
   "requests",
   "selfies",
 ]

--- a/schemist/cleaning.py
+++ b/schemist/cleaning.py
@@ -2,8 +2,10 @@
 
 from carabiner.decorators import vectorize
 
-from datamol import sanitize_smiles
+from rdkit.Chem import MolToSmiles
 import selfies as sf
+
+from .converting import sanitize_smiles_to_mol
 
 @vectorize
 def clean_smiles(smiles: str, 
@@ -13,7 +15,7 @@ def clean_smiles(smiles: str,
     
     """
 
-    return sanitize_smiles(smiles, *args, **kwargs) 
+    return MolToSmiles(sanitize_smiles_to_mol(smiles, *args, **kwargs))
 
 
 @vectorize
@@ -24,4 +26,4 @@ def clean_selfies(selfies: str,
     
     """
 
-    return sf.encode(sanitize_smiles(sf.decode(selfies), *args, **kwargs))
+    return sf.encode(MolToSmiles(sanitize_smiles_to_mol(sf.decode(selfies), *args, **kwargs)))

--- a/schemist/features.py
+++ b/schemist/features.py
@@ -43,7 +43,7 @@ def _get_descriptastorus_features(
 ) -> Union[DataFrame, Tuple[np.ndarray, List[str]]]:
 
     generator = MakeGenerator((generator, ))
-    features = list(map(generator.process, smiles))    
+    features = [generator.processMol(_smiles2mol(s), s) for s in smiles] 
     return np.stack(features, axis=0), [col for col, _ in generator.GetColumns()]
 
 
@@ -96,6 +96,8 @@ def calculate_2d_features(
     CCC     True
     CCCO    True
     Name: meta_feature_valid, dtype: bool
+    >>> s = "O=S(=O)(OCC1OC(OC2(COS(=O)(=O)O[AlH3](O)O)OC(COS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C2OS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C1OS(=O)(=O)O[AlH3](O)O)O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O"
+    >>> calculate_2d_features(strings=s)[0].shape
 
     """  
 

--- a/schemist/features.py
+++ b/schemist/features.py
@@ -9,11 +9,12 @@ from pandas import DataFrame, Series
 import numpy as np
 from rdkit import RDLogger
 RDLogger.DisableLog('rdApp.*')
+from rdkit.Chem import Mol
 
 try:
-    from rdkit.Chem.AllChem import FingeprintGenerator64 as FingerprintGenerator64, GetMorganGenerator, Mol
+    from rdkit.Chem.AllChem import FingeprintGenerator64 as FingerprintGenerator64, GetMorganGenerator
 except ImportError: # typo in some rdkit versions
-    from rdkit.Chem.AllChem import FingerprintGenerator64, GetMorganGenerator, Mol
+    from rdkit.Chem.rdFingerprintGenerator import FingerprintGenerator64, GetMorganGenerator
 
 from .converting import _smiles2mol, _convert_input_to_smiles
 

--- a/schemist/features.py
+++ b/schemist/features.py
@@ -98,6 +98,7 @@ def calculate_2d_features(
     Name: meta_feature_valid, dtype: bool
     >>> s = "O=S(=O)(OCC1OC(OC2(COS(=O)(=O)O[AlH3](O)O)OC(COS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C2OS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C(OS(=O)(=O)O[AlH3](O)O)C1OS(=O)(=O)O[AlH3](O)O)O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O.O[AlH3](O)O"
     >>> calculate_2d_features(strings=s)[0].shape
+    (1, 200)
 
     """  
 


### PR DESCRIPTION
There was inconsistency between rkdit versions as to whether unusual valences were allowed or not, which caused silent failure for 2d feature generation with descriptastorus. This is fixed by turning off blanket sanitation and then enforcing sanitation except for valence checks afterwards. 

This also allowed a broader range of rdkit versions to be used, which in turn supports a wider range of python versions.