### PR TITLE
Fix `'FingerprintGenerator64' object has no attribute 'GetOptions'`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schemist"
-version = "0.0.4"
+version = "0.0.4.post1"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]


### PR DESCRIPTION
Arising from older RDkit versions, such as 2022.9.5. Now the error is caught, and a fallback fingerprint size is generated by parsing a test SMILES string and getting the size of the array.